### PR TITLE
Add cert-manager and external-dns as default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cert-manager and external-dns as default apps.
+
 ### Changed
 
 - Add team label to helm resources.

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -32,6 +32,16 @@ apps:
     forceUpgrade: true
     namespace: kube-system
     version: 2.1.0
+  certManager:
+    appName: cert-manager
+    chartName: cert-manager-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: true
+    namespace: kube-system
+    version: 2.12.0
   coreDNS:
     appName: coredns
     chartName: coredns-app
@@ -42,6 +52,16 @@ apps:
     forceUpgrade: true
     namespace: kube-system
     version: 1.8.0
+  externalDns:
+    appName: external-dns
+    chartName: external-dns-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: true
+    namespace: kube-system
+    version: 2.9.1
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics-app


### PR DESCRIPTION
This PR:

- Adds/changes/removes...

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
