### PR TITLE
Change cert-manager-app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `cert-manager-app` name to `cert-manager` so that we use the same name that when installing from collection.
+
 ## [0.4.0] - 2022-05-13
 
 ## [0.3.0] - 2022-05-12

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -33,7 +33,7 @@ apps:
     namespace: kube-system
     version: 2.1.0
   certManager:
-    appName: cert-manager-app
+    appName: cert-manager
     chartName: cert-manager-app
     catalog: default
     clusterValues:


### PR DESCRIPTION
This PR:

- [After this was merged](https://github.com/giantswarm/mc-bootstrap/pull/178), we need to use the same name for `cert-manager` to be able to adopt the app after the initial bootstrap of the MC.