### PR TITLE
Add workload-identity-operator-gcp admission controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add workload-identity-operator-gcp admission controller.
+
 ## [0.10.1] - 2022-07-14
 
 ### Fixed

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -77,7 +77,7 @@ apps:
       configMap: true
       secret: false
     forceUpgrade: true
-    namespace: giantswarm
+    namespace: kube-system
     version: 0.2.1
   kubeStateMetrics:
     appName: kube-state-metrics
@@ -147,5 +147,5 @@ apps:
       configMap: true
       secret: false
     forceUpgrade: false
-    namespace: giantswarm
+    namespace: kube-system
     version: 0.1.0

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -77,7 +77,7 @@ apps:
       configMap: true
       secret: false
     forceUpgrade: true
-    namespace: kube-system
+    namespace: giantswarm
     version: 0.2.1
   kubeStateMetrics:
     appName: kube-state-metrics
@@ -139,3 +139,13 @@ apps:
     forceUpgrade: false
     namespace: kube-system
     version: 1.0.1
+  workload-identity-operator-gcp:
+    appName: workload-identity-operator-gcp
+    chartName: workload-identity-operator-gcp
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: giantswarm
+    version: 0.1.0


### PR DESCRIPTION
This PR:

- adds workload-identity-operator-gcp admission controller, because we want to use the workload identity provider on all clusters, not only on MCs.