### PR TITLE
Bump external-dns to 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update external-dns to v2.16.0. This version uses workload-identity as an authentication method
+
 ## [0.14.3] - 2022-10-18
 
 ### Changed

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -59,7 +59,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/external-dns-app
-    version: 2.15.4
+    version: 2.16.0
   gcp-compute-persistent-disk-csi-driver-app:
     appName: gcp-compute-persistent-disk-csi-driver
     chartName: gcp-compute-persistent-disk-csi-driver


### PR DESCRIPTION
### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
/test upgrade
