### PR TITLE
Add cluster-resources-app to allow all egress traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-Add cluster-resources-app so that a cilium cluster wide policy is deployed to allow all egress traffic.
+- Add cluster-resources-app so that a cilium cluster wide policy is deployed to allow all egress traffic.
 
 ## [0.15.0] - 2022-11-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Add cluster-resources-app so that a cilium cluster wide policy is deployed to allow all egress traffic.
+
 ## [0.15.0] - 2022-11-09
 
 ### Changed

--- a/helm/default-apps-gcp/values.schema.json
+++ b/helm/default-apps-gcp/values.schema.json
@@ -97,6 +97,40 @@
                         }
                     }
                 },
+                "clusterResources": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "forceUpgrade": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "coreDNS": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -42,6 +42,18 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 2.17.1
+  clusterResources:
+    appName: cluster-resources
+    chartName: cluster-resources
+    catalog: default
+    clusterValues:
+      configMap: false
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/cluster-resources-app
+    version: 0.1.1
   coreDNS:
     appName: coredns
     chartName: coredns-app


### PR DESCRIPTION
### What this PR does / why we need it

Until all our apps that need access to the k8s api server deploy a cilium network policy to allow that traffic, we need a general solution. This app that we are adding deployes a cluster wide network policy to allow all egress traffic.

### Checklist

- [X] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!-- If for some reason you want to skip the e2e tests, remove the following lines. You can check the results of the e2e tests on [tekton](https://tekton.giantswarm.io/). -->

/test create
