### PR TITLE
added dependency to vpa-crd for vpa-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `observability-bundle` from `0.1.9` to `0.2.0`
 
+### Added
+
+- New app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the vertical-pod-autoscaler-app it is not installed until the corresponding CRD app is deployed.
+
 ## [0.18.1] - 2023-01-18
 
 ### Changed

--- a/helm/default-apps-gcp/ci/test-values.yaml
+++ b/helm/default-apps-gcp/ci/test-values.yaml
@@ -1,0 +1,1 @@
+clusterID: test

--- a/helm/default-apps-gcp/templates/apps.yaml
+++ b/helm/default-apps-gcp/templates/apps.yaml
@@ -6,7 +6,7 @@ kind: App
 metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "{{ .forceUpgrade }}"
-    {{- if and .dependsOn }}
+    {{- if .dependsOn }}
     # App is deployed in the org- namespace so the secret name is prefixed by the cluster-id
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
     {{- end }}

--- a/helm/default-apps-gcp/templates/apps.yaml
+++ b/helm/default-apps-gcp/templates/apps.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "{{ .forceUpgrade }}"
     {{- if .dependsOn }}
-    # App is deployed in the org- namespace so the secret name is prefixed by the cluster-id
+    # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
     {{- end }}
   labels:

--- a/helm/default-apps-gcp/templates/apps.yaml
+++ b/helm/default-apps-gcp/templates/apps.yaml
@@ -6,6 +6,10 @@ kind: App
 metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "{{ .forceUpgrade }}"
+    {{- if and .dependsOn }}
+    # App is deployed in the org- namespace so the secret name is prefixed by the cluster-id
+    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
+    {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .inCluster }}

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -109,6 +109,7 @@ apps:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app
     catalog: default
+    dependsOn: vertical-pod-autoscaler-crd
     forceUpgrade: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
### What this PR does / why we need it

towards https://github.com/giantswarm/roadmap/issues/2009

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description 
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
