### PR TITLE
Bump Observability Bundle to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `observability-bundle` from `0.1.9` to `0.2.0`
+- Bump `observability-bundle` to `0.4.0`.
+
+### Removed
+
+- Remove kube-state-metrics app as it is now included in the observability-bundle.
 
 ## [0.18.1] - 2023-01-18
 

--- a/helm/default-apps-gcp/values.schema.json
+++ b/helm/default-apps-gcp/values.schema.json
@@ -166,29 +166,6 @@
                         }
                     }
                 },
-                "kubeStateMetrics": {
-                    "type": "object",
-                    "properties": {
-                        "appName": {
-                            "type": "string"
-                        },
-                        "catalog": {
-                            "type": "string"
-                        },
-                        "chartName": {
-                            "type": "string"
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "metricsServer": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -69,15 +69,6 @@ apps:
     # used by renovate
     # repo: giantswarm/giantswarm/gcp-compute-persistent-disk-csi-driver-app
     version: 0.5.0
-  kubeStateMetrics:
-    appName: kube-state-metrics
-    chartName: kube-state-metrics
-    catalog: default
-    forceUpgrade: true
-    namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/kube-state-metrics-app
-    version: 1.14.2
   metricsServer:
     appName: metrics-server
     chartName: metrics-server-app
@@ -141,4 +132,4 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.2.0
+    version: 0.4.0


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26221

### What this PR does / why we need it
This PR bumps the observability bundle and remove kube-state-metrics as it is now included

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description 
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
/test upgrade
