### PR TITLE
Add chart-operator-extensions and regenerate Helm values.schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set explicit values for `external-dns`.
 - Change team annotation to phoenix from hydra
 
-
 ### Removed
 
 - Remove kube-state-metrics app as it is now included in the observability-bundle.
@@ -22,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the vertical-pod-autoscaler-app it is not installed until the corresponding CRD app is deployed.
+- Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
 
 ## [0.18.1] - 2023-01-18
 

--- a/helm/default-apps-gcp/values.schema.json
+++ b/helm/default-apps-gcp/values.schema.json
@@ -74,6 +74,43 @@
                         }
                     }
                 },
+                "chartOperatorExtensions": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "clusterValues": {
+                            "type": "object",
+                            "properties": {
+                                "configMap": {
+                                    "type": "boolean"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "cilium": {
                     "type": "object",
                     "properties": {
@@ -247,10 +284,10 @@
                         "chartName": {
                             "type": "string"
                         },
-                        "inCluster": {
+                        "forceUpgrade": {
                             "type": "boolean"
                         },
-                        "forceUpgrade": {
+                        "inCluster": {
                             "type": "boolean"
                         },
                         "namespace": {
@@ -271,6 +308,9 @@
                             "type": "string"
                         },
                         "chartName": {
+                            "type": "string"
+                        },
+                        "dependsOn": {
                             "type": "string"
                         },
                         "forceUpgrade": {
@@ -343,6 +383,19 @@
             "properties": {
                 "cilium": {
                     "type": "boolean"
+                },
+                "externalDns": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -56,6 +56,17 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 2.19.0
+  chartOperatorExtensions:
+    appName: chart-operator-extensions
+    chartName: chart-operator-extensions
+    catalog: default
+    enabled: true
+    clusterValues:
+      configMap: true
+      secret: true
+    dependsOn: prometheus-operator-crd
+    namespace: giantswarm
+    version: 1.1.1
   coreDNS:
     appName: coredns
     chartName: coredns-app

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -66,6 +66,8 @@ apps:
       secret: true
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
+    # used by renovate
+    # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
   coreDNS:
     appName: coredns

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -62,8 +62,8 @@ apps:
     catalog: default
     enabled: true
     clusterValues:
-      configMap: true
-      secret: true
+      configMap: false
+      secret: false
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
     # used by renovate


### PR DESCRIPTION
### What this PR does / why we need it

Towards: https://github.com/giantswarm/giantswarm/issues/27558

Add `chart-operator-extensions` that contains service monitors for `chart-operator`. As of that, it depends on `prometheus-operator-crd`.

Also regenerated `values.schema.json` because of the updated `values.yaml` file.

This will fully take effect after bumping chart operator beyond: https://github.com/giantswarm/chart-operator/pull/1029 (Will be released as `chart-operator` version `v3.0.0` probably).

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
