### PR TITLE
Reduce compute persistent disk csi driver app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the vertical-pod-autoscaler-app it is not installed until the corresponding CRD app is deployed.
 - Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
 
+### Fixed
+
+- Shortened `gcp-compute-persistent-disk-csi-driver-app` appName to `gcp-comp-p-disk-csi-driver` to avoid issues with longer cluster names.
+
 ## [0.18.1] - 2023-01-18
 
 ### Changed

--- a/helm/default-apps-gcp/values.yaml
+++ b/helm/default-apps-gcp/values.yaml
@@ -88,7 +88,7 @@ apps:
     # repo: giantswarm/external-dns-app
     version: 2.33.0
   gcp-compute-persistent-disk-csi-driver-app:
-    appName: gcp-compute-persistent-disk-csi-driver
+    appName: gcp-comp-p-disk-csi-driver
     chartName: gcp-compute-persistent-disk-csi-driver
     catalog: default
     forceUpgrade: true


### PR DESCRIPTION
### What this PR does / why we need it

This reduces the gcp-compute-persistent-disk-csi-driver appName that cause the default-apps installation to fail in clusters having longer (>12 characters) names.

Towards https://github.com/giantswarm/giantswarm/issues/28911

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

<!--
We currently have two different pipelines to test both cluster creation and cluster upgrades. You can trigger these pipelines by writing these commands in a pull request comment or description 
- `/test create` : this will trigger the `create-cluster-capi-pure` pipeline.
- `/test upgrade` : this will trigger the `upgrade-cluster-capi-pure` pipeline.

After writing these comments, the pipelines are triggered in [tekton](https://tekton.giantswarm.io/#/pipelineruns). Eventually, the Github checks `create` and `upgrade` for these pipelines should show up in the commit statuses.
It may happen that the status is never shown on Github UI. If you want to check the status or result of the pipelines you can check [tekton](https://tekton.giantswarm.io/#/pipelineruns).

If for some reason you want to skip the e2e tests, remove the following lines.
-->

/test create
